### PR TITLE
Combine avatar selection and generation

### DIFF
--- a/public/matdash/app.js
+++ b/public/matdash/app.js
@@ -5,7 +5,7 @@ class MatDashLMS {
     constructor() {
         this.currentView = 'dashboard';
         this.currentStep = 1;
-        this.maxStep = 9;
+        this.maxStep = 8;
         this.isDarkMode = false;
         this.charts = {};
         this.selectedAvatar = null;
@@ -585,20 +585,64 @@ class MatDashLMS {
                     <div class="step-content active" id="step-2">
                         <div class="form-card">
                             <div class="card-header">
-                                <h3 class="card-title">Choose Your AI Avatar</h3>
-                                <p class="card-subtitle">Select an AI avatar that will present your course content</p>
+                                <h3 class="card-title">Avatar Setup</h3>
+                                <p class="card-subtitle">Select an AI avatar and configure generation settings</p>
                             </div>
                             <div class="card-content">
-                                <div class="avatar-grid" id="wizard-avatar-grid">
-                                    ${this.data.avatars.map(avatar => `
-                                        <div class="avatar-option ${this.selectedAvatar?.id === avatar.id ? 'selected' : ''}" data-avatar-id="${avatar.id}">
-                                            <img src="${avatar.thumbnail}" alt="${avatar.name}">
-                                            <div class="avatar-info">
-                                                <div class="avatar-name">${avatar.name}</div>
-                                                <div class="avatar-style">${avatar.style}</div>
-                                            </div>
+                                <div style="display: grid; grid-template-columns: 1fr 1fr; gap: var(--space-lg);">
+                                    <div>
+                                        <h4>Choose Your AI Avatar</h4>
+                                        <div class="avatar-grid" id="wizard-avatar-grid">
+                                            ${this.data.avatars.map(avatar => `
+                                                <div class="avatar-option ${this.selectedAvatar?.id === avatar.id ? 'selected' : ''}" data-avatar-id="${avatar.id}">
+                                                    <img src="${avatar.thumbnail}" alt="${avatar.name}">
+                                                    <div class="avatar-info">
+                                                        <div class="avatar-name">${avatar.name}</div>
+                                                        <div class="avatar-style">${avatar.style}</div>
+                                                    </div>
+                                                </div>
+                                            `).join('')}
                                         </div>
-                                    `).join('')}
+                                    </div>
+                                    <div>
+                                        <h4>Selected Avatar</h4>
+                                        <div id="selected-avatar-preview" style="text-align: center; padding: var(--space-lg);">
+                                            ${this.selectedAvatar ? `
+                                                <img src="${this.selectedAvatar.thumbnail}" style="width: 120px; height: 120px; border-radius: 50%; object-fit: cover; margin-bottom: var(--space-md);">
+                                                <h5>${this.selectedAvatar.name}</h5>
+                                                <p style="color: var(--text-secondary);">${this.selectedAvatar.style}</p>
+                                            ` : `
+                                                <div style="color: var(--text-secondary);">
+                                                    <div style="font-size: 48px; margin-bottom: var(--space-md);">👤</div>
+                                                    <p>No avatar selected</p>
+                                                </div>
+                                            `}
+                                        </div>
+                                        <h4>Generation Settings</h4>
+                                        <div class="form-group">
+                                            <label class="form-label">Voice Style</label>
+                                            <select class="form-control">
+                                                <option>Professional</option>
+                                                <option>Conversational</option>
+                                                <option>Enthusiastic</option>
+                                            </select>
+                                        </div>
+                                        <div class="form-group">
+                                            <label class="form-label">Language</label>
+                                            <select class="form-control">
+                                                <option>English</option>
+                                                <option>Spanish</option>
+                                                <option>French</option>
+                                            </select>
+                                        </div>
+                                        <div class="form-group">
+                                            <label class="form-label">Script</label>
+                                            <textarea class="form-control" id="avatar-script" rows="4" placeholder="Enter the script for your avatar..."></textarea>
+                                        </div>
+                                        <div style="text-align: center; margin-top: var(--space-lg);">
+                                            <button class="btn btn-primary" onclick="lms.generateAvatar()">Generate Avatar Video</button>
+                                        </div>
+                                    </div>
                                 </div>
                             </div>
                         </div>
@@ -757,60 +801,6 @@ class MatDashLMS {
                     <div class="step-content active" id="step-8">
                         <div class="form-card">
                             <div class="card-header">
-                                <h3 class="card-title">Generate AI Avatar</h3>
-                                <p class="card-subtitle">Create your AI-powered video presentation</p>
-                            </div>
-                            <div class="card-content">
-                                <div style="display: grid; grid-template-columns: 1fr 1fr; gap: var(--space-lg);">
-                                    <div>
-                                        <h4>Selected Avatar</h4>
-                                        <div style="text-align: center; padding: var(--space-lg);">
-                                            ${this.selectedAvatar ? `
-                                                <img src="${this.selectedAvatar.thumbnail}" style="width: 120px; height: 120px; border-radius: 50%; object-fit: cover; margin-bottom: var(--space-md);">
-                                                <h5>${this.selectedAvatar.name}</h5>
-                                                <p style="color: var(--text-secondary);">${this.selectedAvatar.style}</p>
-                                            ` : `
-                                                <div style="color: var(--text-secondary);">
-                                                    <div style="font-size: 48px; margin-bottom: var(--space-md);">👤</div>
-                                                    <p>No avatar selected</p>
-                                                </div>
-                                            `}
-                                        </div>
-                                    </div>
-                                    <div>
-                                        <h4>Generation Settings</h4>
-                                        <div class="form-group">
-                                            <label class="form-label">Voice Style</label>
-                                            <select class="form-control">
-                                                <option>Professional</option>
-                                                <option>Conversational</option>
-                                                <option>Enthusiastic</option>
-                                            </select>
-                                        </div>
-                                        <div class="form-group">
-                                            <label class="form-label">Language</label>
-                                            <select class="form-control">
-                                                <option>English</option>
-                                                <option>Spanish</option>
-                                                <option>French</option>
-                                            </select>
-                                        </div>
-                                    </div>
-                                </div>
-                                <div style="text-align: center; margin-top: var(--space-lg);">
-                                    <button class="btn btn-primary" onclick="lms.generateAvatar()">Generate Avatar Video</button>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                `;
-                break;
-
-            case 9:
-                stepHTML = `
-                    <div class="step-content active" id="step-9">
-                        <div class="form-card">
-                            <div class="card-header">
                                 <h3 class="card-title">Publish Course</h3>
                                 <p class="card-subtitle">Configure sharing and distribution settings</p>
                             </div>
@@ -881,6 +871,14 @@ class MatDashLMS {
                 const avatarId = option.getAttribute('data-avatar-id');
                 this.selectedAvatar = this.data.avatars.find(a => a.id === avatarId);
                 this.showToast('success', 'Avatar Selected', `${this.selectedAvatar.name} selected`);
+                const preview = document.getElementById('selected-avatar-preview');
+                if (preview && this.selectedAvatar) {
+                    preview.innerHTML = `
+                        <img src="${this.selectedAvatar.thumbnail}" style="width: 120px; height: 120px; border-radius: 50%; object-fit: cover; margin-bottom: var(--space-md);">
+                        <h5>${this.selectedAvatar.name}</h5>
+                        <p style="color: var(--text-secondary);">${this.selectedAvatar.style}</p>
+                    `;
+                }
             });
         });
     }

--- a/public/matdash/index.html
+++ b/public/matdash/index.html
@@ -227,7 +227,7 @@
           <div class="page-header">
             <div class="page-header-left">
               <h1 class="page-title">Create New Course</h1>
-              <p class="page-subtitle">Follow the 9-step wizard to create your professional course</p>
+                <p class="page-subtitle">Follow the 8-step wizard to create your professional course</p>
             </div>
           </div>
 
@@ -235,14 +235,13 @@
           <div class="stepper-container">
             <div class="stepper">
               <div class="step complete" data-step="1"><div class="step-number">1</div><div class="step-title">Course Setup</div></div>
-              <div class="step active" data-step="2"><div class="step-number">2</div><div class="step-title">Avatar Selection</div></div>
+                <div class="step active" data-step="2"><div class="step-number">2</div><div class="step-title">Avatar Setup</div></div>
               <div class="step" data-step="3"><div class="step-number">3</div><div class="step-title">Template</div></div>
               <div class="step" data-step="4"><div class="step-number">4</div><div class="step-title">Content Upload</div></div>
               <div class="step" data-step="5"><div class="step-number">5</div><div class="step-title">Course Builder</div></div>
               <div class="step" data-step="6"><div class="step-number">6</div><div class="step-title">Assessments</div></div>
               <div class="step" data-step="7"><div class="step-number">7</div><div class="step-title">Preview</div></div>
-              <div class="step" data-step="8"><div class="step-number">8</div><div class="step-title">Avatar Generate</div></div>
-              <div class="step" data-step="9"><div class="step-number">9</div><div class="step-title">Publish</div></div>
+                <div class="step" data-step="8"><div class="step-number">8</div><div class="step-title">Publish</div></div>
             </div>
           </div>
 
@@ -307,21 +306,59 @@
               </div>
             </div>
 
-            <div class="step-content" id="step-2">
-              <div class="form-card">
-                <div class="card-header">
-                  <h3 class="card-title">Choose Your AI Avatar</h3>
-                  <p class="card-subtitle">Select an AI avatar that will present your course content</p>
-                </div>
-                <div class="card-content">
-                  <div class="avatar-grid" id="wizard-avatar-grid"></div>
+              <div class="step-content" id="step-2">
+                <div class="form-card">
+                  <div class="card-header">
+                    <h3 class="card-title">Avatar Setup</h3>
+                    <p class="card-subtitle">Select an AI avatar and configure generation settings</p>
+                  </div>
+                  <div class="card-content">
+                    <div style="display: grid; grid-template-columns: 1fr 1fr; gap: var(--space-lg);">
+                      <div>
+                        <h4>Choose Your AI Avatar</h4>
+                        <div class="avatar-grid" id="wizard-avatar-grid"></div>
+                      </div>
+                      <div>
+                        <h4>Selected Avatar</h4>
+                        <div id="selected-avatar-preview" style="text-align: center; padding: var(--space-lg);">
+                          <div style="color: var(--text-secondary);">
+                            <div style="font-size: 48px; margin-bottom: var(--space-md);">👤</div>
+                            <p>No avatar selected</p>
+                          </div>
+                        </div>
+                        <h4>Generation Settings</h4>
+                        <div class="form-group">
+                          <label class="form-label">Voice Style</label>
+                          <select class="form-control">
+                            <option>Professional</option>
+                            <option>Conversational</option>
+                            <option>Enthusiastic</option>
+                          </select>
+                        </div>
+                        <div class="form-group">
+                          <label class="form-label">Language</label>
+                          <select class="form-control">
+                            <option>English</option>
+                            <option>Spanish</option>
+                            <option>French</option>
+                          </select>
+                        </div>
+                        <div class="form-group">
+                          <label class="form-label">Script</label>
+                          <textarea class="form-control" id="avatar-script" rows="4" placeholder="Enter the script for your avatar..."></textarea>
+                        </div>
+                        <div style="text-align: center; margin-top: var(--space-lg);">
+                          <button class="btn btn-primary" onclick="lms.generateAvatar()">Generate Avatar Video</button>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
                 </div>
               </div>
-            </div>
 
             <div class="wizard-navigation">
               <button class="btn btn-outline" id="prev-step-btn" disabled><span class="material-icons">arrow_back</span>Previous</button>
-              <div class="wizard-info"><span id="step-indicator">Step 1 of 9</span></div>
+              <div class="wizard-info"><span id="step-indicator">Step 1 of 8</span></div>
               <button class="btn btn-primary" id="next-step-btn">Next<span class="material-icons">arrow_forward</span></button>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Merge avatar selection and generation into a single wizard step
- Reduce course creation wizard to eight steps and update stepper UI
- Support live avatar previews during selection

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot find module '@/components/layouts/DashboardLayout')*

------
https://chatgpt.com/codex/tasks/task_e_68ab24fe4b18832688a331c1736c4bba